### PR TITLE
🛠️ PR: OAuth Google, Naver, Kakao 로그인 기능 구현🚀

### DIFF
--- a/src/main/java/com/trip/IronBird_Server/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/trip/IronBird_Server/oauth/CustomOAuth2User.java
@@ -1,0 +1,31 @@
+package com.trip.IronBird_Server.oauth;
+
+import com.trip.IronBird_Server.user.domain.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private User user;
+    private boolean first;
+
+    public CustomOAuth2User( Map<String, Object> attributes, User user) {
+        super(List.of(new SimpleGrantedAuthority("ROLE_USER")), attributes,"sub");
+        this.user = user;
+        this.first = first;
+    }
+
+    //시큐리티 컨텍스트 내의 인증 정보를 가져와 하는 작업을 수행할 경우
+    //계정 식별자가 사용되도록 조치
+    @Override
+    public String getName(){
+        return String.valueOf(user.getId());
+    }
+}

--- a/src/main/java/com/trip/IronBird_Server/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/trip/IronBird_Server/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,104 @@
+package com.trip.IronBird_Server.oauth;
+
+import com.trip.IronBird_Server.user.domain.entity.User;
+import com.trip.IronBird_Server.user.domain.modeltype.OauthType;
+import com.trip.IronBird_Server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final OAuth2UserService<OAuth2UserRequest,OAuth2User> delegate = new DefaultOAuth2UserService();
+    private final UserRepository userRepository;
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        //기본 OAuth2UserService를 통해 사용자 정보를 가져온다.
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // 어떤 OAuth2 플랫폼(Google, Kakao, Naver)에서 요청이 들어왔는지 확인
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();    //Google, Naver, Kakao 구분
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        OAuth2Attributes oAuth2Attributes;
+
+        if ("google".equals(registrationId)) {
+            oAuth2Attributes = extractGoogleAttributes(attributes);
+        } else if ("kakao".equals(registrationId)) {
+            oAuth2Attributes = extractKakaoAttributes(attributes);
+        } else if ("naver".equals(registrationId)) {
+            oAuth2Attributes = extractNaverAttributes(attributes);
+        } else {
+            throw new OAuth2AuthenticationException("Unsupported registrationId: " + registrationId);
+        }
+
+        String email = oAuth2Attributes.getEmail();
+        String name = oAuth2Attributes.getName();
+        String picture = oAuth2Attributes.getPicture();
+
+        //DB에 회원 정보를 저장하거나 기존 회원 정보를 업데이트
+        User loggedUser = userRepository.findByEmail(email).orElseGet(() -> {
+            log.info("Creating new user with picture: {}", picture);
+            return userRepository.save(
+                    User.createSocialUser(
+                            email,
+                            oAuth2Attributes.getOauth2Id(),
+                            OauthType.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase()),
+                            picture
+                    )
+            );
+        });
+
+        return new CustomOAuth2User(oAuth2Attributes.getAttributes(),loggedUser);
+    }
+
+    // Google 사용자 정보 처리
+    private OAuth2Attributes extractGoogleAttributes(Map<String, Object> attributes) {
+        return OAuth2Attributes.builder()
+                .oauth2Id((String) attributes.get("sub"))  // Google의 고유 ID
+                .email((String) attributes.get("email"))  // 이메일
+                .name((String) attributes.get("name"))    // 이름
+                .picture((String) attributes.get("picture")) // 프로필 사진
+                .attributes(attributes)  // 전체 속성
+                .build();
+    }
+
+    // Kakao 사용자 정보 처리
+    private OAuth2Attributes extractKakaoAttributes(Map<String, Object> attributes) {
+        // Kakao는 kakao_account라는 하위 객체 안에 사용자 정보가 있음
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        return OAuth2Attributes.builder()
+                .oauth2Id(String.valueOf(attributes.get("id")))  // Kakao의 고유 ID
+                .email((String) kakaoAccount.get("email"))       // 이메일
+                .name((String) profile.get("nickname"))          // 닉네임
+                .picture((String) profile.get("profile_image_url")) // 프로필 사진
+                .attributes(attributes)  // 전체 속성
+                .build();
+    }
+
+    // Naver 사용자 정보 처리
+    private OAuth2Attributes extractNaverAttributes(Map<String, Object> attributes) {
+        // Naver는 response라는 하위 객체 안에 사용자 정보가 있음
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuth2Attributes.builder()
+                .oauth2Id((String) response.get("id"))         // Naver의 고유 ID
+                .email((String) response.get("email"))         // 이메일
+                .name((String) response.get("name"))           // 이름
+                .picture((String) response.get("profile_image")) // 프로필 사진
+                .attributes(attributes)  // 전체 속성
+                .build();
+    }
+}

--- a/src/main/java/com/trip/IronBird_Server/oauth/OAuth2Attributes.java
+++ b/src/main/java/com/trip/IronBird_Server/oauth/OAuth2Attributes.java
@@ -1,0 +1,20 @@
+package com.trip.IronBird_Server.oauth;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.Map;
+
+@Value
+@Builder
+public class OAuth2Attributes {
+    String oauth2Id;
+    String email;
+    String name;
+    String picture;
+    Map<String, Object> attributes;
+    String OauthType;
+
+}

--- a/src/main/java/com/trip/IronBird_Server/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/trip/IronBird_Server/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,41 @@
+package com.trip.IronBird_Server.oauth;
+
+import com.trip.IronBird_Server.jwt.TokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final TokenProvider tokenProvider;
+
+    @Value("${app.oauth2.authorized-redirect-uri}")
+    private String redirectUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        FilterChain chain,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        AuthenticationSuccessHandler.super.onAuthenticationSuccess(request, response, chain, authentication);
+
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+    }
+}

--- a/src/main/java/com/trip/IronBird_Server/user/domain/entity/User.java
+++ b/src/main/java/com/trip/IronBird_Server/user/domain/entity/User.java
@@ -40,7 +40,7 @@ public class User {
                 .build();
     }
 
-    public User createSocialUser(String email, String oauthId,OauthType oauthType, String socialProfilePic){
+    public static User createSocialUser(String email, String oauthId,OauthType oauthType, String socialProfilePic){
         return User.builder()
                 .email(email)
                 .oauthId(oauthId)


### PR DESCRIPTION
### ✨ 개요
_Google, Naver, Kakao의 OAuth 로그인 기능을 구현.
각 제공자의 사용자 정보를 처리하고 JWT 토큰 생성 및 리다이렉션 로직을 추가._
---

### ✅ 주요 구현 사항

1. Google OAuth 통합 🌟
- . sub, email, name, picture 속성 매핑 및 처리.

2. Naver OAuth 통합 🇰🇷
-  response 데이터에서 사용자 정보를 추출 (id, email, profile_image).

3. Kakao OAuth 통합 🟡
-  kakao_account와 profile 데이터를 활용하여 사용자 정보를 매핑 (nickname, email, profile_image_url).

4. CustomOAuth2UserService 리팩토링 🔄 
- OAuth2 제공자에 따른 사용자 속성 추출 및 매핑을 통합.
- 동적으로 registrationId를 감지하여 처리.
- OAuth2SuccessHandler 업데이트 ✅

5. 사용자 정보를 기반으로 JWT 토큰 생성.
- 성공적인 인증 이후 클라이언트로 리다이렉션 처리.
---
🎯 향후 개선 사항
Facebook, Github 등 추가 OAuth 제공자 지원.
로그인 실패 시 유저 친화적인 에러 메시지 반환.
속성 매핑 및 인증 흐름 최적화.
🚩 연관 이슈
Resolves #<issue-number>
📌 태그
@team-backend @qa-team

리뷰 및 피드백 부탁드립니다! 💬
