### PR TITLE
:art: Refactor Plan package to follow Clean Architecture

### DIFF
--- a/src/main/java/com/trip/IronBird_Server/plan/adapter/controller/PlanController.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/adapter/controller/PlanController.java
@@ -2,7 +2,7 @@ package com.trip.IronBird_Server.plan.adapter.controller;
 
 import com.trip.IronBird_Server.common.custom.CustomUserDetails;
 import com.trip.IronBird_Server.plan.adapter.dto.PlanDto;
-import com.trip.IronBird_Server.plan.application.service.PlanService;
+import com.trip.IronBird_Server.plan.application.service.PlanServiceImp;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PlanController {
 
-    private final PlanService planService;
+    private final PlanServiceImp planServiceImp;
 
     /**
      @
@@ -25,7 +25,7 @@ public class PlanController {
     @GetMapping
     public List<PlanDto> getAllPlans(){
 
-        return planService.getAllPlans();
+        return planServiceImp.getAllPlans();
     }
 
     /**
@@ -35,7 +35,7 @@ public class PlanController {
     @GetMapping("/user/{userId}")
     public List<PlanDto> getPlansByUserId(@PathVariable("userId") Long userId) {    //PathVariable 에 명시적으로 userId 를 등록하여 경로 변수에 인식
 
-        return planService.getPlansByUserId(userId);
+        return planServiceImp.getPlansByUserId(userId);
     }
 
     /**
@@ -47,7 +47,7 @@ public class PlanController {
                                         @AuthenticationPrincipal CustomUserDetails userDetails){
 
         Long userIdFromToken = userDetails.getId();
-        PlanDto createdPlan = planService.createPlan(planDto,userIdFromToken);
+        PlanDto createdPlan = planServiceImp.createPlan(planDto,userIdFromToken);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdPlan);
     }
 
@@ -59,7 +59,7 @@ public class PlanController {
     @PutMapping("/update/{planId}")
     public ResponseEntity<PlanDto> updatePlanById(@PathVariable("planId") Long planId,
                                                   @RequestBody PlanDto planDto){
-        PlanDto updatePlan = planService.updatePlan(planId, planDto);
+        PlanDto updatePlan = planServiceImp.updatePlan(planId, planDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(updatePlan);
     }
 
@@ -70,7 +70,7 @@ public class PlanController {
     @DeleteMapping("/{planId}")
     public ResponseEntity<String> deletePlan(@PathVariable("planId") Long PlanId){
         try {
-            planService.deletePlan(PlanId);
+            planServiceImp.deletePlan(PlanId);
 
             return ResponseEntity.ok("플랜이 삭제되었습니다.");
         }catch (Exception e){

--- a/src/main/java/com/trip/IronBird_Server/plan/adapter/dto/PlanMapper.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/adapter/dto/PlanMapper.java
@@ -1,0 +1,18 @@
+package com.trip.IronBird_Server.plan.adapter.dto;
+
+import com.trip.IronBird_Server.plan.domain.Plan;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlanMapper {
+    public PlanDto toDto(Plan plan){
+        return PlanDto.builder()
+                .id(plan.getId())
+                .userId(plan.getUser().getId())
+                .startedDate(plan.getStartedDate())
+                .endDate(plan.getEndDate())
+                .createdTime(plan.getCreated_time())
+                .modifiedTime(plan.getModified_time())
+                .build();
+    }
+}

--- a/src/main/java/com/trip/IronBird_Server/plan/application/service/PlanService.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/application/service/PlanService.java
@@ -1,118 +1,14 @@
 package com.trip.IronBird_Server.plan.application.service;
 
-import com.trip.IronBird_Server.plan.domain.Plan;
 import com.trip.IronBird_Server.plan.adapter.dto.PlanDto;
-import com.trip.IronBird_Server.plan.infrastructure.PlanRepository;
-import com.trip.IronBird_Server.user.domain.entity.User;
-import com.trip.IronBird_Server.user.infrastructure.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
-@Service
-@RequiredArgsConstructor
-public class PlanService {
-
-    private final PlanRepository planRepository;
-    private final UserRepository userRepository;
-
-    // 모든 플랜 조회
-    public List<PlanDto> getAllPlans() {
-        return planRepository.findAll().stream()
-                .map(plan -> PlanDto.builder()
-                        .id(plan.getId())
-                        .userId(plan.getUser().getId())
-                        .startedDate(plan.getStartedDate())
-                        .endDate(plan.getEndDate())
-                        .createdTime(plan.getCreated_time())
-                        .modifiedTime(plan.getModified_time())
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    // 특정 유저의 플랜 조회
-    public List<PlanDto> getPlansByUserId(Long userId){
-        return planRepository.findByUserId(userId).stream()
-                .map(plan -> PlanDto.builder()
-                        .id(plan.getId())
-                        .userId(plan.getUser().getId())
-                        .startedDate(plan.getStartedDate())
-                        .endDate(plan.getEndDate())
-                        .createdTime(plan.getCreated_time())
-                        .modifiedTime(plan.getModified_time())
-                        .build())
-                .collect(Collectors.toList());
-    }
 
 
-    //플랜 생성 서비스
-    @Transactional
-    public PlanDto createPlan(PlanDto planDto, Long userIdFromToken){
-        User user = userRepository.findById(userIdFromToken)
-                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + userIdFromToken));
-
-
-        Plan plan = Plan.builder()
-                .startedDate(planDto.getStartedDate())
-                .endDate(planDto.getEndDate())
-                .user(user) //user 설정
-                .build();
-
-
-        //User 는 외부에서 가져오기
-        Plan savedPlan = planRepository.save(plan);
-        return PlanDto.builder()
-                .id(savedPlan.getId())
-                .userId(userRepository.findById(userIdFromToken).orElseThrow(() -> new EntityNotFoundException("User not found")).getId())
-                .startedDate(savedPlan.getStartedDate())
-                .endDate(savedPlan.getEndDate())
-                .createdTime(savedPlan.getCreated_time())
-                .modifiedTime(savedPlan.getModified_time())
-                .build();
-    }
-
-
-    //플랜 수정 서비스
-    @Transactional
-    public PlanDto updatePlan(Long id,PlanDto planDto){
-
-        //기존 플랜 조회
-        Plan exitPlan = planRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Plan Not found with ID : " + id));
-
-//        if(!exitPlan.getUser().getId().equals(userId)){
-//            throw new UnauthorizedException("User is not authorized to update this plan.");
-//        }
-
-        //변경할 데이터 가져와서 엔티티에 등록
-        exitPlan.setStartedDate(planDto.getStartedDate());
-        exitPlan.setEndDate(planDto.getEndDate());
-
-        //수정된 데이터 저장
-        Plan updatePlan = planRepository.save(exitPlan);
-
-        // 저장된 결과를 PlanDto로 변환하여 반환
-        return PlanDto.builder()
-                .id(updatePlan.getId())
-                .userId(updatePlan.getUser().getId())
-                .startedDate(updatePlan.getStartedDate())
-                .endDate(updatePlan.getEndDate())
-                .createdTime(updatePlan.getCreated_time())
-                .modifiedTime(updatePlan.getModified_time())
-                .build();
-    }
-
-    //플랜 삭제 서비스
-    public void deletePlan(Long id){
-        Plan plan = planRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("게시물을 찾을 수 없습니다."));
-
-        planRepository.delete(plan);
-    }
-
-
+public interface PlanService {
+    public List<PlanDto> getAllPlans(); //모든 플랜 가져오기
+    public List<PlanDto> getPlansByUserId(Long userId); //유저아이디별 플랜 가져오기
+    public PlanDto createPlan(PlanDto planDto, Long userIdFromToken); // 플랜 생성
+    public PlanDto updatePlan(Long id,PlanDto planDto); //플랜 수정
+    public void deletePlan(Long id); // 플랜 삭제
 }

--- a/src/main/java/com/trip/IronBird_Server/plan/application/service/PlanServiceImp.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/application/service/PlanServiceImp.java
@@ -1,0 +1,104 @@
+package com.trip.IronBird_Server.plan.application.service;
+
+import com.trip.IronBird_Server.plan.adapter.dto.PlanMapper;
+import com.trip.IronBird_Server.plan.domain.Plan;
+import com.trip.IronBird_Server.plan.adapter.dto.PlanDto;
+import com.trip.IronBird_Server.plan.infrastructure.PlanRepository;
+import com.trip.IronBird_Server.user.domain.entity.User;
+import com.trip.IronBird_Server.user.infrastructure.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlanServiceImp implements PlanService {
+
+    private final PlanRepository planRepository;
+    private final UserRepository userRepository;
+    private final PlanMapper planMapper;
+
+    /**
+     * 모든 플랜 가져오기
+     * @return
+     */
+    @Override
+    public List<PlanDto> getAllPlans() {
+        return planRepository.findAll().stream()
+                .map(planMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 유저의 플랜 조회
+     * @param userId
+     * @return
+     */
+    @Override
+    public List<PlanDto> getPlansByUserId(Long userId){
+        return planRepository.findByUserId(userId).stream()
+                .map(planMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * 플랜 생성 서비스
+     * @param planDto
+     * @param userIdFromToken
+     * @return
+     */
+    @Override
+    public PlanDto createPlan(PlanDto planDto, Long userIdFromToken){
+        User user = userRepository.findById(userIdFromToken)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + userIdFromToken));
+
+
+        Plan plan = Plan.builder()
+                .startedDate(planDto.getStartedDate())
+                .endDate(planDto.getEndDate())
+                .user(user) //user 설정
+                .build();
+
+
+        //User 는 외부에서 가져오기
+        Plan savedPlan = planRepository.save(plan);
+        return planMapper.toDto(savedPlan);
+    }
+
+
+    //플랜 수정 서비스
+    @Override
+    public PlanDto updatePlan(Long id,PlanDto planDto){
+
+        //기존 플랜 조회
+        Plan exitPlan = planRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Plan Not found with ID : " + id));
+
+
+        //변경할 데이터 가져와서 엔티티에 등록
+        exitPlan.updateDates(planDto.getStartedDate(), planDto.getEndDate());
+
+        //수정된 데이터 저장
+        Plan updatePlan = planRepository.save(exitPlan);
+
+        // 저장된 결과를 PlanDto로 변환하여 반환
+        return planMapper.toDto(updatePlan);
+    }
+
+    //플랜 삭제 서비스
+    @Override
+    public void deletePlan(Long id){
+        Plan plan = planRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("게시물을 찾을 수 없습니다."));
+
+        planRepository.delete(plan);
+    }
+
+
+}

--- a/src/main/java/com/trip/IronBird_Server/plan/domain/Plan.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/domain/Plan.java
@@ -14,8 +14,6 @@ import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Entity
 public class Plan {
 
@@ -42,4 +40,18 @@ public class Plan {
     private LocalDateTime modified_time;
 
 
+    @Builder
+    public Plan(User user, String startedDate, String endDate, LocalDateTime created_time, LocalDateTime modified_time) {
+
+        this.user = user;
+        this.startedDate = startedDate;
+        this.endDate = endDate;
+        this.created_time = created_time;
+        this.modified_time = modified_time;
+    }
+    public void updateDates(String startedDate, String endDate) {
+        this.startedDate = startedDate;
+        this.endDate = endDate;
+        this.modified_time = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
## 😄 개요
기존 레이어드 아키텍처인 플랜 패키지 부분을 클린 아키텍처로 변환
비즈니스 로직 (Use Case)을 중심으로 설계하여 유지보수성과 확장성을 높임.


## ✨ 주요 변경 사항
- Plan 패키지를 클린 아키텍처 구조로 리팩토링
1. Use Case 중심으로 비즈니스 로직을 재구성
2. 기존 Service 계층을 UseCase로 변경
3. Entity, Repository, Controller를 각각 도메인 중심으로 분리

- 의존성 역전을 통해 Domain Layer가 외부에 의존하지 않도록 변경
- 기존 서비스 로직에서 도메인 규칙을 직접 다루던 부분을 UseCase에 위임
- 필요 없는 기존 레이어드 아키텍처 관련 코드 제거


## 🎯 변경이유
- 기존 레이어드 아키텍처에서는 비즈니스 로직이 Service 계층에 집중되면서 도메인과 분리가 명확하지 않음.
- UseCase 중심으로 변경함으로써 비즈니스 로직이 더욱 독립적으로 관리 가능