### PR TITLE
Feature/clean architecture

### DIFF
--- a/src/main/java/com/trip/IronBird_Server/plan/adapter/mapper/PlanMapper.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/adapter/mapper/PlanMapper.java
@@ -1,5 +1,6 @@
-package com.trip.IronBird_Server.plan.adapter.dto;
+package com.trip.IronBird_Server.plan.adapter.mapper;
 
+import com.trip.IronBird_Server.plan.adapter.dto.PlanDto;
 import com.trip.IronBird_Server.plan.domain.Plan;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/trip/IronBird_Server/plan/application/service/PlanServiceImp.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/application/service/PlanServiceImp.java
@@ -1,6 +1,6 @@
 package com.trip.IronBird_Server.plan.application.service;
 
-import com.trip.IronBird_Server.plan.adapter.dto.PlanMapper;
+import com.trip.IronBird_Server.plan.adapter.mapper.PlanMapper;
 import com.trip.IronBird_Server.plan.domain.Plan;
 import com.trip.IronBird_Server.plan.adapter.dto.PlanDto;
 import com.trip.IronBird_Server.plan.infrastructure.PlanRepository;

--- a/src/main/java/com/trip/IronBird_Server/post/adapter/controller/PostController.java
+++ b/src/main/java/com/trip/IronBird_Server/post/adapter/controller/PostController.java
@@ -2,12 +2,11 @@ package com.trip.IronBird_Server.post.adapter.controller;
 
 import com.trip.IronBird_Server.common.custom.CustomUserDetails;
 import com.trip.IronBird_Server.post.adapter.dto.PostDto;
-import com.trip.IronBird_Server.post.application.service.PostService;
+import com.trip.IronBird_Server.post.application.service.PostServiceImp;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostController {
 
-    private final PostService postService;
+    private final PostServiceImp postServiceImp;
 
     /**
      * 등록된 포스팅 전체 가져오는 컨트롤러
@@ -25,7 +24,7 @@ public class PostController {
     @GetMapping
     public List<PostDto> getAllPost(){
 
-        return postService.getAllPosts();
+        return postServiceImp.getAllPosts();
     }
 
 
@@ -39,7 +38,7 @@ public class PostController {
             throw new IllegalArgumentException("인증 정보가 없습니다.");
         }
         String email = userDetails.getEmail();  // 이메일 가져오기
-        PostDto createdPost = postService.createPost(postDto, email);
+        PostDto createdPost = postServiceImp.createPost(postDto, email);
         return new ResponseEntity<>(createdPost, HttpStatus.CREATED);
     }
 
@@ -51,7 +50,7 @@ public class PostController {
     @PutMapping("/update/{postId}")
     public ResponseEntity<?> updatePost(@RequestBody PostDto postDto,
                                         @PathVariable("postId") Long postId){
-        PostDto updateDto = postService.updatePost(postId, postDto);
+        PostDto updateDto = postServiceImp.updatePost(postId, postDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(updateDto);
     }
@@ -62,7 +61,7 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<String> deletePost(@PathVariable("postId") Long postId){
         try{
-            postService.deletePost(postId);
+            postServiceImp.deletePost(postId);
 
             return ResponseEntity.ok("게시물이 삭제되었습니다.");
         }catch (Exception e){

--- a/src/main/java/com/trip/IronBird_Server/post/adapter/mapper/PostMapper.java
+++ b/src/main/java/com/trip/IronBird_Server/post/adapter/mapper/PostMapper.java
@@ -1,0 +1,22 @@
+package com.trip.IronBird_Server.post.adapter.mapper;
+
+import com.trip.IronBird_Server.post.adapter.dto.PostDto;
+import com.trip.IronBird_Server.post.domain.Post;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostMapper {
+
+    public PostDto postDto(Post post){
+        return PostDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .detail(post.getDetail())
+                .userName(post.getUser().getName())
+                .planId(post.getPlan().getId())
+                .createTime(post.getCreateTime())
+                .modifyTime(post.getModifyTime())
+                .build();
+    }
+
+}

--- a/src/main/java/com/trip/IronBird_Server/post/application/service/PostService.java
+++ b/src/main/java/com/trip/IronBird_Server/post/application/service/PostService.java
@@ -1,141 +1,14 @@
 package com.trip.IronBird_Server.post.application.service;
 
-import com.trip.IronBird_Server.plan.domain.Plan;
-import com.trip.IronBird_Server.plan.infrastructure.PlanRepository;
-import com.trip.IronBird_Server.post.domain.Post;
 import com.trip.IronBird_Server.post.adapter.dto.PostDto;
-import com.trip.IronBird_Server.post.infrastructure.PostRepository;
-import com.trip.IronBird_Server.user.domain.entity.User;
-import com.trip.IronBird_Server.user.infrastructure.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
-@Service
-@RequiredArgsConstructor
-@Slf4j
-public class PostService {
+public interface PostService {
 
-    private final PostRepository postRepository;
-    private final UserRepository userRepository;
-    private final PlanRepository planRepository;
-
-
-    // 모든 게시물 조회
-    public List<PostDto> getAllPosts(){
-        return postRepository.findAll().stream()
-                .map(post -> PostDto.builder()
-                        .id(post.getId())
-                        .title(post.getTitle())
-                        .detail(post.getDetail())
-                        .userName(post.getUser().getName())
-                        .planId(post.getPlan() != null ? post.getPlan().getId() : null) // Plan 이 null 이라면 null 반환
-                        .createTime(post.getCreateTime())
-                        .modifyTime(post.getModifyTime())
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-
-    // 게시물 생성
-    public PostDto createPost(PostDto postDto, String email) {
-        // 사용자 조회
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-        // Plan 조회
-        Plan plan = null;
-        if (postDto.getPlanId() != null) {
-            plan = planRepository.findById(postDto.getPlanId())
-                    .orElseThrow(() -> new IllegalArgumentException("Plan ID: " + postDto.getPlanId() + "를 찾을 수 없습니다."));
-        } else {
-            log.warn("Plan ID가 제공되지 않았습니다. Plan 없이 게시물을 생성합니다.");
-        }
-
-        LocalDateTime now = LocalDateTime.now();
-
-        // Post 엔티티 생성 및 저장
-        Post post = Post.builder()
-                .title(postDto.getTitle())
-                .detail(postDto.getDetail())
-                .user(user)
-                .plan(plan)
-                .createTime(now)
-                .modifyTime(now)
-                .build();
-
-        Post savedPost = postRepository.save(post);
-        log.debug("Saved Post Plan ID: {}", savedPost.getPlan() != null ? savedPost.getPlan().getId() : "NULL");
-
-        return PostDto.builder()
-                .id(savedPost.getId())
-                .title(savedPost.getTitle())
-                .detail(savedPost.getDetail())
-                .userName(user.getName())
-                .planId(savedPost.getPlan() != null ? savedPost.getPlan().getId() : null)
-                .createTime(savedPost.getCreateTime())
-                .modifyTime(savedPost.getModifyTime())
-                .build();
-    }
-
-
-    // 게시물 수정
-    @Transactional
-    public PostDto updatePost(Long id, PostDto postDto){
-
-        //기존 게시물 조회
-        Post exitPost = postRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Post Not Found"));
-
-
-        exitPost.setTitle(postDto.getTitle());
-        exitPost.setDetail(postDto.getDetail());
-        exitPost.setModifyTime(LocalDateTime.now());
-
-        //수정된 데이터 저장
-        Post updatePost = postRepository.save(exitPost);
-
-        // 저장된 결과를 PostDto로 반환
-        return PostDto.builder()
-                .id(updatePost.getId())
-                .userName(updatePost.getUser().getName())
-                .title(updatePost.getTitle())
-                .detail(updatePost.getDetail())
-                .planId(updatePost.getPlan().getId())
-                .modifyTime(updatePost.getModifyTime())
-                .build();
-    }
-
-
-    //게시물 삭제
-    public void deletePost(Long id){
-        Post post = postRepository.findById(id)
-                .orElseThrow(()-> new RuntimeException("게시물을 찾을 수 없습니다."));
-
-        postRepository.delete(post);
-
-    }
-
-
-    /**
-     * 좋아요 관리
-     */
-
-    //좋아요 증가
-    public void incrementLike(Long postId){
-        Post post = postRepository.findById(postId)
-                .orElseThrow(()-> new EntityNotFoundException("Post not found"));
-        post.setLikeCount(post.getLikeCount() + 1);
-        postRepository.save(post);
-    }
-
-
-
+    public List<PostDto> getAllPosts();
+    public PostDto createPost(PostDto postDto, String email);
+    public PostDto updatePost(Long id, PostDto postDto);
+    public void deletePost(Long id);
+    public void incrementLike(Long postId);
 }

--- a/src/main/java/com/trip/IronBird_Server/post/application/service/PostServiceImp.java
+++ b/src/main/java/com/trip/IronBird_Server/post/application/service/PostServiceImp.java
@@ -1,0 +1,137 @@
+package com.trip.IronBird_Server.post.application.service;
+
+import com.trip.IronBird_Server.plan.domain.Plan;
+import com.trip.IronBird_Server.plan.infrastructure.PlanRepository;
+import com.trip.IronBird_Server.post.adapter.mapper.PostMapper;
+import com.trip.IronBird_Server.post.domain.Post;
+import com.trip.IronBird_Server.post.adapter.dto.PostDto;
+import com.trip.IronBird_Server.post.infrastructure.PostRepository;
+import com.trip.IronBird_Server.user.domain.entity.User;
+import com.trip.IronBird_Server.user.infrastructure.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostServiceImp implements PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final PlanRepository planRepository;
+    private final PostMapper postMapper;
+
+
+    /**
+     * 모든 게시물 조회
+     * @return
+     */
+    @Override
+    public List<PostDto> getAllPosts(){
+        return postRepository.findAll().stream()
+                .map(postMapper::postDto)
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * 게시물 생성
+     * @param postDto
+     * @param email
+     * @return
+     */
+    @Override
+    public PostDto createPost(PostDto postDto, String email) {
+        // 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // Plan 조회
+        Plan plan = null;
+        if (postDto.getPlanId() != null) {
+            plan = planRepository.findById(postDto.getPlanId())
+                    .orElseThrow(() -> new IllegalArgumentException("Plan ID: " + postDto.getPlanId() + "를 찾을 수 없습니다."));
+        } else {
+            log.warn("Plan ID가 제공되지 않았습니다. Plan 없이 게시물을 생성합니다.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // Post 엔티티 생성 및 저장
+        Post post = Post.builder()
+                .title(postDto.getTitle())
+                .detail(postDto.getDetail())
+                .user(user)
+                .plan(plan)
+                .createTime(now)
+                .modifyTime(now)
+                .build();
+
+        Post savedPost = postRepository.save(post);
+        log.debug("Saved Post Plan ID: {}", savedPost.getPlan() != null ? savedPost.getPlan().getId() : "NULL");
+
+        return postMapper.postDto(savedPost);
+    }
+
+
+    /**
+     * 게시물 수정
+     * @param id
+     * @param postDto
+     * @return
+     */
+    @Transactional
+    @Override
+    public PostDto updatePost(Long id, PostDto postDto){
+
+        //기존 게시물 조회
+        Post exitPost = postRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Post Not Found"));
+
+
+        exitPost.setTitle(postDto.getTitle());
+        exitPost.setDetail(postDto.getDetail());
+        exitPost.setModifyTime(LocalDateTime.now());
+
+        //수정된 데이터 저장
+        Post updatePost = postRepository.save(exitPost);
+
+        // 저장된 결과를 PostDto로 반환
+        return postMapper.postDto(updatePost);
+    }
+
+
+    //게시물 삭제
+    @Override
+    public void deletePost(Long id){
+        Post post = postRepository.findById(id)
+                .orElseThrow(()-> new RuntimeException("게시물을 찾을 수 없습니다."));
+
+        postRepository.delete(post);
+
+    }
+
+
+    /**
+     * 좋아요 관리
+     */
+
+    //좋아요 증가
+    @Override
+    public void incrementLike(Long postId){
+        Post post = postRepository.findById(postId)
+                .orElseThrow(()-> new EntityNotFoundException("Post not found"));
+        post.setLikeCount(post.getLikeCount() + 1);
+        postRepository.save(post);
+    }
+
+
+
+}


### PR DESCRIPTION
## 😄 개요
기존 레이어드 아키텍처인 플랜 패키지 부분을 클린 아키텍처로 변환
비즈니스 로직 (Use Case)을 중심으로 설계하여 유지보수성과 확장성을 높임.


## ✨ 주요 변경 사항
- Post 패키지를 클린 아키텍처 구조로 리팩토링
1. Use Case 중심으로 비즈니스 로직을 재구성
2. 기존 Service 계층을 UseCase로 변경
3. Entity, Repository, Controller를 각각 도메인 중심으로 분리

- 의존성 역전을 통해 Domain Layer가 외부에 의존하지 않도록 변경
- 기존 서비스 로직에서 도메인 규칙을 직접 다루던 부분을 UseCase에 위임
- 필요 없는 기존 레이어드 아키텍처 관련 코드 제거


## 🎯 변경이유
- 기존 레이어드 아키텍처에서는 비즈니스 로직이 Service 계층에 집중되면서 도메인과 분리가 명확하지 않음.
- UseCase 중심으로 변경함으로써 비즈니스 로직이 더욱 독립적으로 관리 가능