### PR TITLE
:hammer: kakao Login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	// https://mvnrepository.com/artifact/com.google.code.gson/gson
 	implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
 
+	// https://mvnrepository.com/artifact/org.json/json
+	implementation group: 'org.json', name: 'json', version: '20250107'
+
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/trip/IronBird_Server/user/adapter/controller/UserApiController.java
+++ b/src/main/java/com/trip/IronBird_Server/user/adapter/controller/UserApiController.java
@@ -1,0 +1,41 @@
+package com.trip.IronBird_Server.user.adapter.controller;
+
+import com.trip.IronBird_Server.jwt.TokenProvider;
+import com.trip.IronBird_Server.user.adapter.dto.KakaoUserInfoDto;
+import com.trip.IronBird_Server.user.application.KakaoAuthService;
+import com.trip.IronBird_Server.user.infrastructure.KakaoApiClientImp;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class UserApiController {
+
+    private final KakaoAuthService kakaoAuthService;
+    private final TokenProvider tokenProvider;
+
+    /**
+     * KakaoLogin
+     * @param requestBody
+     * @return
+     */
+    @PostMapping("/kakao")
+    public ResponseEntity<?> kakaoLogin(@RequestBody Map<String, String> requestBody){
+        String kakaoAccessToken = requestBody.get("access_token");
+
+        //kakao 사용자 정보 가져오기
+        KakaoUserInfoDto kakaoUserInfoDto = kakaoAuthService.authenticate(kakaoAccessToken);
+
+        //JWT 발급
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/trip/IronBird_Server/user/adapter/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/trip/IronBird_Server/user/adapter/dto/KakaoUserInfoDto.java
@@ -1,0 +1,15 @@
+package com.trip.IronBird_Server.user.adapter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    private String email;
+    private String nickname;
+
+}

--- a/src/main/java/com/trip/IronBird_Server/user/application/KakaoAuthService.java
+++ b/src/main/java/com/trip/IronBird_Server/user/application/KakaoAuthService.java
@@ -1,0 +1,19 @@
+package com.trip.IronBird_Server.user.application;
+
+import com.trip.IronBird_Server.user.adapter.dto.KakaoUserInfoDto;
+import com.trip.IronBird_Server.user.infrastructure.KakaoApiClientImp;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+    private final KakaoApiClientImp kakaoApiClientImp;
+
+    public KakaoUserInfoDto authenticate(String accessToken){
+        return kakaoApiClientImp.getKakaoUserInfo(accessToken);
+    }
+
+
+}

--- a/src/main/java/com/trip/IronBird_Server/user/application/service/KakaoService.java
+++ b/src/main/java/com/trip/IronBird_Server/user/application/service/KakaoService.java
@@ -1,0 +1,9 @@
+package com.trip.IronBird_Server.user.application.service;
+
+
+import com.trip.IronBird_Server.user.adapter.dto.KakaoUserInfoDto;
+
+public interface KakaoService {
+
+    KakaoUserInfoDto getKakaoUserInfo(String accessToken);
+}

--- a/src/main/java/com/trip/IronBird_Server/user/infrastructure/KakaoApiClientImp.java
+++ b/src/main/java/com/trip/IronBird_Server/user/infrastructure/KakaoApiClientImp.java
@@ -1,0 +1,49 @@
+package com.trip.IronBird_Server.user.infrastructure;
+
+import com.trip.IronBird_Server.user.adapter.dto.KakaoUserInfoDto;
+import com.trip.IronBird_Server.user.application.service.KakaoService;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoApiClientImp implements KakaoService {
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public KakaoUserInfoDto getKakaoUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                entity,
+                String.class
+        );
+
+        if(response.getStatusCode() == HttpStatus.OK){
+            return getKakaoUserInfo(response.getBody());
+        }else {
+            throw new RuntimeException("카카오 사용자 정보 요청 실패");
+        }
+    }
+
+    private KakaoUserInfoDto parseKakaoUser(String responseBody){
+        JSONObject json = new JSONObject(responseBody);
+        JSONObject kakaoAccount = json.getJSONObject("kakao_account");
+
+        return new KakaoUserInfoDto(
+                json.getLong("id"),
+                kakaoAccount.getString("email"),
+                kakaoAccount.getJSONObject("profile").getString("nickname")
+        );
+    }
+}


### PR DESCRIPTION
## 🚀  개요
- kakaoLogin 구현중

## 🔨설명
### 1.프론트에서 카카오 로그인을 완료한 후, accessToken을 백엔드로 보냄

📌 API 엔드포인트
`POST /api/auth/kakao`

- 프론트에서 Jetpack Compose를 사용하여 카카오 로그인을 진행한 후, 받은 access_token을 이 API로 전송

📌 예상 요청 (프론트 -> 백엔드)
```
{
   "access_token" : "카카오에서 받은 엑세스 토큰"
}
```


### 2.백엔드에서 access_token을 검증하고 사용자 정보 요청
- 백엔드는 받은 access_token을 사용하여 카카오 사용자 정보 API에 요청을 보내서 사용자 정보를 가져와야 함.

📌 kakao UserInfo API
`GET https://kapi.kakao.com/v2/user/me`
- 헤더에 `Authorization: Bearer {access_token} `포함해야 함.

