### PR TITLE
:dancer: [Feature] 관광 지역코드 API 파싱 및 DB 저장 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,10 @@ dependencies {
 	// https://mvnrepository.com/artifact/io.netty/netty-resolver-dns-native-macos
 	runtimeOnly group: 'io.netty', name: 'netty-resolver-dns-native-macos', version: '4.1.114.Final'
 
-	// https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml
-	implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.3")
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.2'
 
-	// https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
-	implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.18.3")
 
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
 
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 

--- a/src/main/java/com/trip/IronBird_Server/config/RestTemplateConfig.java
+++ b/src/main/java/com/trip/IronBird_Server/config/RestTemplateConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.cbor.MappingJackson2CborHttpMessageConverter;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
@@ -18,16 +19,12 @@ public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
         RestTemplate restTemplate = new RestTemplate();
-        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        //List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        List<HttpMessageConverter<?>> messageConverters = restTemplate.getMessageConverters();
 
         //XML 처리용 메시지 컨버터 추가
-//        List<HttpMessageConverter<?>> messageConverters1 = restTemplate.getMessageConverters();
-//        messageConverters1.add(new MappingJackson2CborHttpMessageConverter(new XmlMapper()));
+        messageConverters.add(new MappingJackson2XmlHttpMessageConverter(new XmlMapper()));
 
-        // JSON 처리용 메시지 컨버터 추가
-//        List<HttpMessageConverter<?>> messageConverters2 = restTemplate.getMessageConverters();
-//        messageConverters2.removeIf(converter -> converter instanceof MappingJackson2CborHttpMessageConverter);
-//        messageConverters2.add(new MappingJackson2JsonHttpMessageConverter());
 
         messageConverters.add(new FormHttpMessageConverter());
         restTemplate.setMessageConverters(messageConverters);

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/controller/TourController.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/controller/TourController.java
@@ -3,6 +3,7 @@ package com.trip.IronBird_Server.plan.tour.adapter.controller;
 import com.trip.IronBird_Server.plan.tour.adapter.dto.TourAreaRoot;
 import com.trip.IronBird_Server.plan.tour.application.service.TourService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +19,7 @@ public class TourController {
     @GetMapping("/areas")
     public ResponseEntity<?> getTourList(){
         TourAreaRoot tourAreaRoot = tourService.getTourAreaList();
-
-        return ResponseEntity.ok(tourAreaRoot.getResponse().getBody().getItems());
+        return ResponseEntity.ok(tourAreaRoot); // 전체 반환
     }
+
 }

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaBody.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaBody.java
@@ -1,5 +1,6 @@
 package com.trip.IronBird_Server.plan.tour.adapter.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,10 +9,11 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TourAreaBody {
 
     @JsonProperty("items")
-    private TourAreaItem items;
+    private TourAreaItems items;
 
     @JsonProperty("numOfRows")
     private int numOfRows;
@@ -21,6 +23,5 @@ public class TourAreaBody {
 
     @JsonProperty("totalCount")
     private int totalCount;
-
-
 }
+

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaHeader.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaHeader.java
@@ -1,5 +1,6 @@
 package com.trip.IronBird_Server.plan.tour.adapter.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TourAreaHeader {
 
     @JsonProperty("resultCode")
@@ -15,5 +17,5 @@ public class TourAreaHeader {
 
     @JsonProperty("resultMsg")
     private String resultMsg;
-
 }
+

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaItem.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaItem.java
@@ -1,6 +1,7 @@
 package com.trip.IronBird_Server.plan.tour.adapter.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,8 +12,13 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TourAreaItem {
 
+    @JsonProperty("rnum")
     private int rnum;
-    private String code;
-    private String name;
 
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("name")
+    private String name;
 }
+

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaItems.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaItems.java
@@ -1,5 +1,6 @@
 package com.trip.IronBird_Server.plan.tour.adapter.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,10 +9,12 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TourAreaItems {
 
     @JsonProperty("item")
     private List<TourAreaItem> item;
 }
+

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaResponse.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaResponse.java
@@ -1,5 +1,6 @@
 package com.trip.IronBird_Server.plan.tour.adapter.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TourAreaResponse {
 
     @JsonProperty("header")
@@ -15,6 +17,5 @@ public class TourAreaResponse {
 
     @JsonProperty("body")
     private TourAreaBody body;
-
-
 }
+

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaRoot.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/adapter/dto/TourAreaRoot.java
@@ -1,16 +1,17 @@
 package com.trip.IronBird_Server.plan.tour.adapter.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TourAreaRoot {
 
     @JsonProperty("response")
     private TourAreaResponse response;
-
 }

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/application/service/TourService.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/application/service/TourService.java
@@ -1,41 +1,84 @@
 package com.trip.IronBird_Server.plan.tour.application.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.trip.IronBird_Server.plan.tour.adapter.dto.TourAreaItem;
 import com.trip.IronBird_Server.plan.tour.adapter.dto.TourAreaRoot;
+import com.trip.IronBird_Server.plan.tour.domain.Tour;
+import com.trip.IronBird_Server.plan.tour.infrastructure.TourAreaRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 @Service
+@Slf4j
 public class TourService {
 
     private final RestTemplate restTemplate;
     private final String apiUrl;
+    private final String serviceKey;
     private final ObjectMapper objectMapper;
 
-    private TourService(RestTemplate restTemplate,
-                        @Value("${tourapi.url}") String apiUrl,
-                        ObjectMapper objectMapper){
+    private final TourAreaRepository tourAreaRepository;
+
+    public TourService(RestTemplate restTemplate,
+                       @Value("${tourapi.url}") String apiUrl,
+                       @Value("${tourapi.service-key}") String serviceKey,
+                       ObjectMapper objectMapper, TourAreaRepository tourAreaRepository) {
         this.restTemplate = restTemplate;
         this.apiUrl = apiUrl;
+        this.serviceKey = serviceKey;
         this.objectMapper = objectMapper;
+        this.tourAreaRepository = tourAreaRepository;
     }
 
-    public TourAreaRoot getTourAreaList(){
-        //API 호출
-        TourAreaRoot response = restTemplate.getForObject(apiUrl, TourAreaRoot.class);
+    public TourAreaRoot getTourAreaList() {
+        try {
+            String encodedServiceKey = URLEncoder.encode(serviceKey, StandardCharsets.UTF_8);
+            String fullUrl = apiUrl + "?serviceKey=" + encodedServiceKey + "&numOfRows=10&pageNo=1&MobileOS=ETC&MobileApp=AppTest&_type=json";
+            URI uri = new URI(fullUrl);
 
-        //응답이 null or Error Code 반환시 예외 발생
-        if(response == null || !"0000".equals(response.getResponse().getHeader().getResultCode())){
-            throw new RuntimeException("관광정보 API 호출 실패");
+            log.info("Request URL: {}", uri);
+
+            // API 호출
+            String responseStr = restTemplate.getForObject(uri, String.class);
+            log.info("Response: {}", responseStr);
+
+            // JSON 파싱
+            TourAreaRoot result = objectMapper.readValue(responseStr, TourAreaRoot.class);
+
+            //DB 저장
+            List<TourAreaItem> items = result.getResponse().getBody().getItems().getItem();
+            for (TourAreaItem item : items) {
+
+                    Tour tourArea = Tour.builder()
+                            .rnum(item.getRnum())
+                            .code(item.getCode())
+                            .name(item.getName())
+                            .build();
+
+                    tourAreaRepository.save(tourArea);
+            }
+
+            if (result == null || result.getResponse() == null) {
+                throw new RuntimeException("응답 구조가 잘못되었습니다 (response null)");
+            }
+
+            if (!"0000".equals(result.getResponse().getHeader().getResultCode())) {
+                throw new RuntimeException("Tour API 호출 실패: " + result.getResponse().getHeader().getResultMsg());
+            }
+
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException("Tour API 호출 또는 파싱 실패", e);
         }
-
-        //ObjectMapper를 사용하여 JSON 응답을 DTO로 변환
-        if(!"0000".equals(response.getResponse().getHeader().getResultCode())){
-            throw new RuntimeException("관광정보 API 호출 실패 : " + response.getResponse().getHeader().getResultMsg());
-        }
-
-        return response;
-
     }
+
 }

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/domain/Tour.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/domain/Tour.java
@@ -1,0 +1,27 @@
+package com.trip.IronBird_Server.plan.tour.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tour_area")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Tour {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int rnum;
+
+    private String code;
+
+    private String name;
+
+}

--- a/src/main/java/com/trip/IronBird_Server/plan/tour/infrastructure/TourAreaRepository.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/tour/infrastructure/TourAreaRepository.java
@@ -1,0 +1,8 @@
+package com.trip.IronBird_Server.plan.tour.infrastructure;
+
+import com.trip.IronBird_Server.plan.tour.domain.Tour;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TourAreaRepository extends JpaRepository<Tour, Long> {
+    boolean existsByCode(String code);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,8 +22,9 @@ spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=20MB
 
-# ???? api
-tourapi.url = http://apis.data.go.kr/B551011/KorService1/areaCode1?serviceKey=kCeJEqUhRvHims6fgvvCaNPOuhMwtpCEGbXXZ4fdp9QojhaFas6y3ujjNjvJSgPGrGcd%2BTy980FL7M9cvTMnJw%3D%3D&numOfRows=20&pageNo=1&MobileOS=ETC&MobileApp=AppTest&_type=json
+# Tour API
+tourapi.url=http://apis.data.go.kr/B551011/KorService1/areaCode1
+tourapi.service-key=kCeJEqUhRvHims6fgvvCaNPOuhMwtpCEGbXXZ4fdp9QojhaFas6y3ujjNjvJSgPGrGcd+Ty980FL7M9cvTMnJw==
 
 
 #JWT Configuration


### PR DESCRIPTION
## 🚀 개요
- 외부 관광 지역코드 API 데이터를 파싱하여 지역 정보를 관리하고자 함.
- 주기적 또는 초기 데이터 세팅을 위해 DB에 저장하는 기능 구현.


## 🔥 주요 변경 사항
- `TourController`: 지역 코드 조회 API 엔드포인트 추가
- `TourService`: API 파싱 로직 구현, 데이터베이스 저장 처리
- `Tour`, `TourAreaRoot`, `TourAreaResponse` 등 DTO 정의 및 매핑


## 👍  기존 (실패) PR 작업 목록
- #67 
- #66 


## 🐛 주요 이슈 & 해결
- `SERVICE_KEY_IS_NOT_REGISTERED_ERROR` 발생 → 서비스 키 인코딩 처리로 해결
- XML → JSON 변환 실패 → `_type=json` 파라미터 추가로 해결
- DTO 파싱 실패 → JSON 구조 맞춰 DTO 수정



## 📄 참고

 관련 벨로그 참고: 
- [공공데이터 포털 service key is not registered error 해결 방법](https://velog.io/@cco2416/%EC%A1%B8%EC%97%85%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%EA%B3%B5%EA%B3%B5%EB%8D%B0%EC%9D%B4%ED%84%B0-%ED%8F%AC%ED%84%B8-service-key-is-not-registered-error-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95)
- [Open API Json Date DTO 객체 만들기 (직렬화 / 역직렬화) + JSON 데이터의 장점](https://velog.io/@7_06com/Open-API-Json-Date-DTO-%EA%B0%9D%EC%B2%B4-%EB%A7%8C%EB%93%A4%EA%B8%B0-%EC%A7%81%EB%A0%AC%ED%99%94-%EC%97%AD%EC%A7%81%EB%A0%AC%ED%99%94)
- [JSON을 DTO로 변환하는 방법 (ObjectMapper 사용법)](https://targetcoders.com/objectmapper-%EC%82%AC%EC%9A%A9%EB%B2%95/)
