### PR TITLE
 :feelsgood: [Feature] Add Schedule

### DIFF
--- a/src/main/java/com/trip/IronBird_Server/plan/adapter/controller/PlanController.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/adapter/controller/PlanController.java
@@ -2,7 +2,10 @@ package com.trip.IronBird_Server.plan.adapter.controller;
 
 import com.trip.IronBird_Server.common.custom.CustomUserDetails;
 import com.trip.IronBird_Server.plan.adapter.dto.PlanDto;
+import com.trip.IronBird_Server.plan.adapter.dto.ScheduleDto;
+import com.trip.IronBird_Server.plan.application.service.PlanService;
 import com.trip.IronBird_Server.plan.application.service.PlanServiceImp;
+import com.trip.IronBird_Server.plan.application.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +19,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PlanController {
 
-    private final PlanServiceImp planServiceImp;
+    private final PlanService planService;
+    private final ScheduleService scheduleService;
 
     /**
      @
@@ -25,7 +29,7 @@ public class PlanController {
     @GetMapping
     public List<PlanDto> getAllPlans(){
 
-        return planServiceImp.getAllPlans();
+        return planService.getAllPlans();
     }
 
     /**
@@ -35,7 +39,7 @@ public class PlanController {
     @GetMapping("/user/{userId}")
     public List<PlanDto> getPlansByUserId(@PathVariable("userId") Long userId) {    //PathVariable 에 명시적으로 userId 를 등록하여 경로 변수에 인식
 
-        return planServiceImp.getPlansByUserId(userId);
+        return planService.getPlansByUserId(userId);
     }
 
     /**
@@ -47,7 +51,7 @@ public class PlanController {
                                         @AuthenticationPrincipal CustomUserDetails userDetails){
 
         Long userIdFromToken = userDetails.getId();
-        PlanDto createdPlan = planServiceImp.createPlan(planDto,userIdFromToken);
+        PlanDto createdPlan = planService.createPlan(planDto,userIdFromToken);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdPlan);
     }
 
@@ -59,7 +63,7 @@ public class PlanController {
     @PutMapping("/update/{planId}")
     public ResponseEntity<PlanDto> updatePlanById(@PathVariable("planId") Long planId,
                                                   @RequestBody PlanDto planDto){
-        PlanDto updatePlan = planServiceImp.updatePlan(planId, planDto);
+        PlanDto updatePlan = planService.updatePlan(planId, planDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(updatePlan);
     }
 
@@ -70,12 +74,26 @@ public class PlanController {
     @DeleteMapping("/{planId}")
     public ResponseEntity<String> deletePlan(@PathVariable("planId") Long PlanId){
         try {
-            planServiceImp.deletePlan(PlanId);
+            planService.deletePlan(PlanId);
 
             return ResponseEntity.ok("플랜이 삭제되었습니다.");
         }catch (Exception e){
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("플랜이 삭제되었습니다.");
         }
+    }
+
+    /**
+     * 스케쥴 생성 컨트롤러
+     * @param planId
+     * @param scheduleDto
+     * @return
+     */
+    @PostMapping("/{planId}/schedules")
+    public ResponseEntity<ScheduleDto> createSchedule(@PathVariable("planId") Long planId,
+                                                      @RequestBody ScheduleDto scheduleDto){
+        ScheduleDto createSchedule = scheduleService.createSchedule(scheduleDto, planId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(createSchedule);
     }
 
 

--- a/src/main/java/com/trip/IronBird_Server/plan/adapter/dto/PlanDto.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/adapter/dto/PlanDto.java
@@ -1,6 +1,7 @@
 package com.trip.IronBird_Server.plan.adapter.dto;
 
 import com.trip.IronBird_Server.plan.domain.Plan;
+import com.trip.IronBird_Server.plan.domain.Schedule;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.checkerframework.checker.units.qual.N;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -16,8 +18,13 @@ import java.time.LocalDateTime;
 public class PlanDto {
     private Long id;
     private Long userId;
+    private String userName; //유저 닉네임(이름)
+    private String destination;
     private String startedDate;
     private String endDate;
     private LocalDateTime createdTime;
     private LocalDateTime modifiedTime;
+
+    // 스케쥴 dto
+    private List<ScheduleDto> schedules;
 }

--- a/src/main/java/com/trip/IronBird_Server/plan/adapter/dto/ScheduleDto.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/adapter/dto/ScheduleDto.java
@@ -1,0 +1,21 @@
+package com.trip.IronBird_Server.plan.adapter.dto;
+
+import com.trip.IronBird_Server.plan.domain.Plan;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ScheduleDto {
+    private Long id;
+    private int day;
+    private String time;
+    private String description;
+    private int cost;
+    private String memo;
+    private Long planId;
+}

--- a/src/main/java/com/trip/IronBird_Server/plan/adapter/mapper/PlanMapper.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/adapter/mapper/PlanMapper.java
@@ -2,18 +2,32 @@ package com.trip.IronBird_Server.plan.adapter.mapper;
 
 import com.trip.IronBird_Server.plan.adapter.dto.PlanDto;
 import com.trip.IronBird_Server.plan.domain.Plan;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
 @Component
+@RequiredArgsConstructor
 public class PlanMapper {
+
+    private final ScheduleMapper scheduleMapper;
     public PlanDto toDto(Plan plan){
         return PlanDto.builder()
                 .id(plan.getId())
                 .userId(plan.getUser().getId())
+                .userName(plan.getUser().getName())
+                .destination(plan.getDestination())
                 .startedDate(plan.getStartedDate())
                 .endDate(plan.getEndDate())
                 .createdTime(plan.getCreated_time())
                 .modifiedTime(plan.getModified_time())
+                .schedules( plan.getSchedules() != null
+                        ? plan.getSchedules().stream()
+                        .map(scheduleMapper::schedulMapper)
+                        .collect(Collectors.toList())
+                        : new ArrayList<>() )
                 .build();
     }
 }

--- a/src/main/java/com/trip/IronBird_Server/plan/adapter/mapper/ScheduleMapper.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/adapter/mapper/ScheduleMapper.java
@@ -1,0 +1,24 @@
+package com.trip.IronBird_Server.plan.adapter.mapper;
+
+import com.trip.IronBird_Server.plan.adapter.dto.ScheduleDto;
+import com.trip.IronBird_Server.plan.domain.Schedule;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScheduleMapper {
+
+    public ScheduleDto schedulMapper(Schedule schedule){
+        return ScheduleDto.builder()
+                .id(schedule.getId())
+                .day(schedule.getDay())
+                .time(schedule.getTime())
+                .description(schedule.getDescription())
+                .cost(schedule.getCost())
+                .memo(schedule.getMemo())
+                .planId(schedule.getPlan() != null ? schedule.getPlan().getId() : null)
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/com/trip/IronBird_Server/plan/application/service/PlanServiceImp.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/application/service/PlanServiceImp.java
@@ -4,6 +4,7 @@ import com.trip.IronBird_Server.plan.adapter.mapper.PlanMapper;
 import com.trip.IronBird_Server.plan.domain.Plan;
 import com.trip.IronBird_Server.plan.adapter.dto.PlanDto;
 import com.trip.IronBird_Server.plan.infrastructure.PlanRepository;
+import com.trip.IronBird_Server.plan.infrastructure.ScheduleRepository;
 import com.trip.IronBird_Server.user.domain.entity.User;
 import com.trip.IronBird_Server.user.infrastructure.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -60,6 +61,7 @@ public class PlanServiceImp implements PlanService {
 
 
         Plan plan = Plan.builder()
+                .destination(planDto.getDestination())
                 .startedDate(planDto.getStartedDate())
                 .endDate(planDto.getEndDate())
                 .user(user) //user 설정
@@ -82,7 +84,7 @@ public class PlanServiceImp implements PlanService {
 
 
         //변경할 데이터 가져와서 엔티티에 등록
-        exitPlan.updateDates(planDto.getStartedDate(), planDto.getEndDate());
+        //exitPlan.updateDates(planDto.getDestination(), planDto.getStartedDate(), planDto.getEndDate());
 
         //수정된 데이터 저장
         Plan updatePlan = planRepository.save(exitPlan);

--- a/src/main/java/com/trip/IronBird_Server/plan/application/service/ScheduleService.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/application/service/ScheduleService.java
@@ -1,0 +1,9 @@
+package com.trip.IronBird_Server.plan.application.service;
+
+
+import com.trip.IronBird_Server.plan.adapter.dto.ScheduleDto;
+
+public interface ScheduleService {
+
+    public ScheduleDto createSchedule(ScheduleDto scheduleDto, Long planId);
+}

--- a/src/main/java/com/trip/IronBird_Server/plan/application/service/ScheduleServiceImp.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/application/service/ScheduleServiceImp.java
@@ -1,0 +1,37 @@
+package com.trip.IronBird_Server.plan.application.service;
+
+import com.trip.IronBird_Server.plan.adapter.dto.ScheduleDto;
+import com.trip.IronBird_Server.plan.adapter.mapper.ScheduleMapper;
+import com.trip.IronBird_Server.plan.domain.Plan;
+import com.trip.IronBird_Server.plan.domain.Schedule;
+import com.trip.IronBird_Server.plan.infrastructure.PlanRepository;
+import com.trip.IronBird_Server.plan.infrastructure.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleServiceImp implements ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final PlanRepository planRepository;
+    private final ScheduleMapper scheduleMapper;
+
+    @Override
+    public ScheduleDto createSchedule(ScheduleDto scheduleDto, Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new IllegalArgumentException("Plan not found with id: " + planId));
+
+        Schedule schedule = Schedule.builder()
+                .day(scheduleDto.getDay())
+                .cost(scheduleDto.getCost())
+                .description(scheduleDto.getDescription())
+                .time(scheduleDto.getTime())
+                .memo(scheduleDto.getMemo())
+                .plan(plan)
+                .build();
+
+        Schedule savedSchedule = scheduleRepository.save(schedule);
+        return scheduleMapper.schedulMapper(savedSchedule);
+    }
+}

--- a/src/main/java/com/trip/IronBird_Server/plan/domain/Plan.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/domain/Plan.java
@@ -6,15 +6,18 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.checkerframework.checker.units.qual.N;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
+@AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Builder
 public class Plan {
 
     @Id
@@ -24,6 +27,8 @@ public class Plan {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    private String destination;
 
     @Column(name="started_Date")
     private String startedDate;
@@ -39,19 +44,7 @@ public class Plan {
     @Column(name="modified_time")
     private LocalDateTime modified_time;
 
-
-    @Builder
-    public Plan(User user, String startedDate, String endDate, LocalDateTime created_time, LocalDateTime modified_time) {
-
-        this.user = user;
-        this.startedDate = startedDate;
-        this.endDate = endDate;
-        this.created_time = created_time;
-        this.modified_time = modified_time;
-    }
-    public void updateDates(String startedDate, String endDate) {
-        this.startedDate = startedDate;
-        this.endDate = endDate;
-        this.modified_time = LocalDateTime.now();
-    }
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
+    @Column(name="schedules_id", nullable = false)
+    private List<Schedule> schedules = new ArrayList<>();
 }

--- a/src/main/java/com/trip/IronBird_Server/plan/domain/Schedule.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/domain/Schedule.java
@@ -1,0 +1,35 @@
+package com.trip.IronBird_Server.plan.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int day;
+
+    private String time;
+
+    private String description;
+
+    private int cost;
+
+    private String memo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+
+}

--- a/src/main/java/com/trip/IronBird_Server/plan/infrastructure/ScheduleRepository.java
+++ b/src/main/java/com/trip/IronBird_Server/plan/infrastructure/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.trip.IronBird_Server.plan.infrastructure;
+
+import com.trip.IronBird_Server.plan.domain.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule,Long> {
+}


### PR DESCRIPTION
## 🚀 개요
- **플랜에 연결된 스케줄 기능 추가**
- 기존 Plan 엔티티에 Schedule 리스트가 포함되도록 확장
- 플랜 생성 이후, 해당 플랜에 스케줄을 등록할 수 있도록 API 구현


## 📌 API 정보

**[POST] 스케줄 등록**

`/api/plan/planId/schedules`


- 특정 플랜에 대한 스케줄 등록
- `{planId}`는 스케줄이 소속될 플랜의 ID


## ✅ 응답 예시 (플랜 + 스케줄 포함 조회)

```json
[
  {
    "id": 18,
    "userId": 8,
    "userName": "yhj",
    "destination": "인천",
    "startedDate": "2025-04-01",
    "endDate": "2025-04-30",
    "createdTime": "2025-04-15T16:07:26.118257",
    "modifiedTime": "2025-04-15T16:07:26.118296",
    "schedules": [
      {
        "id": 5,
        "day": 1,
        "time": "08:00",
        "description": "미마루 스위트 교토 시즈",
        "cost": 320000,
        "memo": "8시에 도착해야됨",
        "planId": 18
      }
    ]
  }
]
